### PR TITLE
Code review for 6.1.1 global stylesheet cache testing plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Moves global stylesheet from transient to WP_Object_Cache, and resolves an inlin
 See [Trac 56970](https://core.trac.wordpress.org/ticket/56970) for additional details.
 
 ## Purpose
-If testing with this plugin is shown to resolve the issues reported in [Trac 56970](https://core.trac.wordpress.org/ticket/56970), then the [proposed fix](https://github.com/WordPress/wordpress-develop/pull/3712) will be included in a future 6.1.2 minor release.
+If testing with this plugin is shown to resolve the issues reported in [Trac 56970](https://core.trac.wordpress.org/ticket/56970), then the [proposed fix](https://github.com/WordPress/wordpress-develop/pull/3712) could be included in a future minor release.
 
 ## Installation
 Copy `hotfix-56970.php` to your `wp-content/plugins/` folder, and activate it on the *Plugins > Installed Plugins* screen.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hotfix for Trac 56970
 
-Cleans `theme.json` cache, and resolves an inline CSS issue related to Gallery blocks when upgrading to WordPress 6.1.1 from 5.8 through 6.0.3. Global styles transient-based caching was introduced in 5.8.
+Cleans `theme.json` cache, and resolves an inline CSS issue related to Gallery blocks when upgrading to WordPress 6.1.1. Tested with starting version of 5.9.5 and 6.0.3.
 
 See <a href="https://core.trac.wordpress.org/ticket/56970">Trac 56970</a> for additional details.
 
@@ -8,7 +8,7 @@ See <a href="https://core.trac.wordpress.org/ticket/56970">Trac 56970</a> for ad
 Copy `hotfix-56970.php` to your `wp-content/plugins/` folder, and activate it on the *Plugins > Installed Plugins* screen.
 
 ## Testing
-Testing requires starting with a standard WordPress install of version 5.8 through 6.0.3. Steps adapted from [Trac 56970#comment:42](https://core.trac.wordpress.org/ticket/56970#comment:42).
+Testing requires starting with a standard WordPress install of version 5.9 through 6.0.3. Steps adapted from [Trac 56970#comment:42](https://core.trac.wordpress.org/ticket/56970#comment:42).
 
 1. Create a new site using WordPress 5.9 through 6.0.3.
 2. Navigate to *Appearance > Themes* and activate **Twenty Twenty-One**.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hotfix for Trac 56970
+# Test for Trac 56970
 
 Cleans `theme.json` cache, and resolves an inline CSS issue related to Gallery blocks when upgrading to WordPress 6.1.1. Tested with starting version of 5.9.5 and 6.0.3.
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Testing requires starting with a standard WordPress install of version 5.9 throu
 3. Navigate to *Settings > Permalinks* and select anything *except for* the "Plain" structure.
 4. Navigate to *Posts > Add New*. Insert a Gallery block and add three images.
 5. Save the post and view it on the frontend. Confirm that the images are displayed in 3 columns.
-6. [Install and activate the hotfix plugin](#installation).
+6. [Install and activate the test plugin](#installation).
 7. Upgrade the site to WordPress 6.1.1.
 8. View the same post from Step 4, and confirm that it displays the images in 3 columns on the frontend.
 9. Navigate to *Posts > All Posts* and edit the post. Confirm that the images in the block editor are displayed in 3 columns and no errors occur.
 
 ## Reporting Issues
-Please open an issue in [this hotfix plugin repository](https://github.com/ironprogrammer/wp-hotfix-56970/issues).
+Please open an issue in [this test plugin repository](https://github.com/ironprogrammer/wp-hotfix-56970/issues).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
-Hotfix for Trac 56970
+# Hotfix for Trac 56970
 
-Cleans theme.json cache. See <a href="https://core.trac.wordpress.org/ticket/56970">Trac 56970</a>.
+Cleans `theme.json` cache, and resolves an inline CSS issue related to Gallery blocks when upgrading to WordPress 6.1.1 from 5.8 through 6.0.3. Global styles transient-based caching was introduced in 5.8.
+
+See <a href="https://core.trac.wordpress.org/ticket/56970">Trac 56970</a> for additional details.
+
+## Installation
+Copy `hotfix-56970.php` to your `wp-content/plugins/` folder, and activate it on the *Plugins > Installed Plugins* screen.
+
+## Testing
+Testing requires starting with a standard WordPress install of version 5.8 through 6.0.3. Steps adapted from [Trac 56970#comment:42](https://core.trac.wordpress.org/ticket/56970#comment:42).
+
+1. Create a new site using WordPress 5.8 through 6.0.3.
+2. Navigate to *Appearance > Themes* and activate **Twenty Twenty-One**.
+3. Navigate to *Posts > Add New*. Insert a Gallery block and add three images.
+4. Save the post and view it on the frontend. Confirm that the images are displayed in 3 columns.
+5. [Install and activate the hotfix plugin](#installation).
+6. Upgrade the site to WordPress 6.1.1.
+7. View the same post from Step 4, and confirm that it displays the images in 3 columns on the frontend.
+8. Navigate to *Posts > All Posts* and edit the post. Confirm that the images in the block editor are displayed in 3 columns and no errors occur.
+
+## Reporting Issues
+Please open an issue in [this hotfix plugin repository](https://github.com/ironprogrammer/wp-hotfix-56970/issues).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# wp-hotfix-56970
+Hotfix for Trac 56970

--- a/README.md
+++ b/README.md
@@ -10,14 +10,15 @@ Copy `hotfix-56970.php` to your `wp-content/plugins/` folder, and activate it on
 ## Testing
 Testing requires starting with a standard WordPress install of version 5.8 through 6.0.3. Steps adapted from [Trac 56970#comment:42](https://core.trac.wordpress.org/ticket/56970#comment:42).
 
-1. Create a new site using WordPress 5.8 through 6.0.3.
+1. Create a new site using WordPress 5.9 through 6.0.3.
 2. Navigate to *Appearance > Themes* and activate **Twenty Twenty-One**.
-3. Navigate to *Posts > Add New*. Insert a Gallery block and add three images.
-4. Save the post and view it on the frontend. Confirm that the images are displayed in 3 columns.
-5. [Install and activate the hotfix plugin](#installation).
-6. Upgrade the site to WordPress 6.1.1.
-7. View the same post from Step 4, and confirm that it displays the images in 3 columns on the frontend.
-8. Navigate to *Posts > All Posts* and edit the post. Confirm that the images in the block editor are displayed in 3 columns and no errors occur.
+3. Navigate to *Settings > Permalinks* and select anything *except for* the "Plain" structure.
+4. Navigate to *Posts > Add New*. Insert a Gallery block and add three images.
+5. Save the post and view it on the frontend. Confirm that the images are displayed in 3 columns.
+6. [Install and activate the hotfix plugin](#installation).
+7. Upgrade the site to WordPress 6.1.1.
+8. View the same post from Step 4, and confirm that it displays the images in 3 columns on the frontend.
+9. Navigate to *Posts > All Posts* and edit the post. Confirm that the images in the block editor are displayed in 3 columns and no errors occur.
 
 ## Reporting Issues
 Please open an issue in [this hotfix plugin repository](https://github.com/ironprogrammer/wp-hotfix-56970/issues).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 Cleans `theme.json` cache, and resolves an inline CSS issue related to Gallery blocks when upgrading to WordPress 6.1.1. Tested with starting version of 5.9.5 and 6.0.3.
 
-See <a href="https://core.trac.wordpress.org/ticket/56970">Trac 56970</a> for additional details.
+See [Trac 56970](https://core.trac.wordpress.org/ticket/56970) for additional details.
+
+## Purpose
+If testing with this plugin is shown to resolve the issues reported in [Trac 56970](https://core.trac.wordpress.org/ticket/56970), then the [proposed fix](https://github.com/WordPress/wordpress-develop/pull/3712) will be included in a future 6.1.2 minor release.
 
 ## Installation
 Copy `hotfix-56970.php` to your `wp-content/plugins/` folder, and activate it on the *Plugins > Installed Plugins* screen.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Test for Trac 56970
 
-Cleans `theme.json` cache, and resolves an inline CSS issue related to Gallery blocks when upgrading to WordPress 6.1.1. Tested with starting version of 5.9.5 and 6.0.3.
+Moves global stylesheet from transient to WP_Object_Cache, and resolves an inline CSS issue related to Gallery blocks when upgrading to WordPress 6.1.1. Tested with starting version of 5.9.5 and 6.0.3.
 
 See [Trac 56970](https://core.trac.wordpress.org/ticket/56970) for additional details.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# wp-hotfix-56970
 Hotfix for Trac 56970
+
+Cleans theme.json cache. See <a href="https://core.trac.wordpress.org/ticket/56970">Trac 56970</a>.

--- a/hotfix-56970.php
+++ b/hotfix-56970.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Plugin Name: Hotfix for Trac 56970
  * Description: Cleans theme.json cache. See <a href="https://core.trac.wordpress.org/ticket/56970">Trac 56970</a>.
+ * Plugin Name: Test for Trac 56970
  * Version: 0.1
  */
 

--- a/hotfix-56970.php
+++ b/hotfix-56970.php
@@ -5,3 +5,11 @@
  * Version: 0.1
  */
 
+// Initialize plugin.
+WP_Hotfix_56970_Controller::init();
+
+class WP_Hotfix_56970_Controller {
+    public static function init() {
+    }
+}
+

--- a/hotfix-56970.php
+++ b/hotfix-56970.php
@@ -27,6 +27,9 @@ function wp_hotfix_56970_init() {
         add_action( 'wp_enqueue_scripts', 'wp_hotfix_611_enqueue_global_styles' );
         add_action( 'wp_footer', 'wp_hotfix_611_enqueue_global_styles', 1 );
 
+        // Hook override for block editor styles.
+        add_filter( 'block_editor_settings_all', 'wp_hotfix_611_get_block_editor_settings', PHP_INT_MAX );
+
         // Unhook default cache cleaning mechanism.
         remove_action( 'switch_theme', array( 'WP_Theme_JSON_Resolver', 'clean_cached_data' ) );
         remove_action( 'start_previewing_theme', array( 'WP_Theme_JSON_Resolver', 'clean_cached_data' ) );
@@ -157,6 +160,16 @@ function wp_hotfix_611_get_global_stylesheet( $types = array() ) {
         wp_cache_set( $cache_key, $stylesheet, $cache_group );
     }
     return $stylesheet;
+}
+
+/**
+ * Add styles to the block editor settings.
+ *
+ * @param array $settings Existing block editor settings.
+ * @return array New block editor settings.
+ */
+function wp_hotfix_611_get_block_editor_settings( $settings ) {
+    return $settings;
 }
 
 /**

--- a/hotfix-56970.php
+++ b/hotfix-56970.php
@@ -15,5 +15,10 @@ class WP_Hotfix_56970_Controller {
 }
 
 function wp_hotfix_56970_init() {
+    global $wp_version;
+
+    // Issue described in Trac 56970 only affects upgrade from < 6.1 to 6.1.1.
+    if ( '6.1.1' === $wp_version ) {
+    }
 }
 

--- a/hotfix-56970.php
+++ b/hotfix-56970.php
@@ -10,6 +10,10 @@ WP_Hotfix_56970_Controller::init();
 
 class WP_Hotfix_56970_Controller {
     public static function init() {
+        add_action( 'init', 'wp_hotfix_56970_init' );
     }
+}
+
+function wp_hotfix_56970_init() {
 }
 

--- a/hotfix-56970.php
+++ b/hotfix-56970.php
@@ -19,6 +19,29 @@ function wp_hotfix_56970_init() {
 
     // Issue described in Trac 56970 only affects upgrade from < 6.1 to 6.1.1.
     if ( '6.1.1' === $wp_version ) {
+        // Unhook default cache cleaning mechanism.
+        remove_action( 'switch_theme', array( 'WP_Theme_JSON_Resolver', 'clean_cached_data' ) );
+        remove_action( 'start_previewing_theme', array( 'WP_Theme_JSON_Resolver', 'clean_cached_data' ) );
+
+        // Hook override cache cleaning mechanism.
+        add_action( 'switch_theme', 'wp_hotfix_611_wp_clean_theme_json_caches' );
+        add_action( 'start_previewing_theme', 'wp_hotfix_611_wp_clean_theme_json_caches' );
+        add_action( 'plugins_loaded', 'wp_hotfix_611_wp_add_non_persistent_theme_json_cache_group' );
     }
 }
 
+/**
+ * Clean the caches under the theme_json group.
+ */
+function wp_hotfix_611_wp_clean_theme_json_caches() {
+    wp_cache_delete( 'wp_get_global_stylesheet', 'theme_json' );
+    WP_Theme_JSON_Resolver::clean_cached_data();
+}
+
+/**
+ * Tell cache mechanisms not to persist theme.json data across requests for data
+ * stored under the wp_get_global_stylesheet cache group.
+ */
+function wp_hotfix_611_wp_add_non_persistent_theme_json_cache_group() {
+    wp_cache_add_non_persistent_groups( 'theme_json' );
+}

--- a/hotfix-56970.php
+++ b/hotfix-56970.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Description: Cleans theme.json cache. See <a href="https://core.trac.wordpress.org/ticket/56970">Trac 56970</a>.
  * Plugin Name: Test for Trac 56970
+ * Description: Moves global stylesheet from transient to WP_Object_Cache. See <a href="https://core.trac.wordpress.org/ticket/56970">Trac 56970</a>.
  * Version: 0.1
  */
 

--- a/hotfix-56970.php
+++ b/hotfix-56970.php
@@ -9,36 +9,36 @@
 WP_Hotfix_56970_Controller::init();
 
 class WP_Hotfix_56970_Controller {
-    public static function init() {
-        add_action( 'init', 'wp_hotfix_56970_init' );
-    }
+	public static function init() {
+		add_action( 'init', 'wp_hotfix_56970_init' );
+	}
 }
 
 function wp_hotfix_56970_init() {
-    global $wp_version;
+	global $wp_version;
 
-    // Issue described in Trac 56970 only affects upgrade from < 6.1 to 6.1.1.
-    if ( '6.1.1' === $wp_version ) {
-        // Unhook default global styles enqueue.
-        remove_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );
-        remove_action( 'wp_footer', 'wp_enqueue_global_styles', 1 );
+	// Issue described in Trac 56970 only affects upgrade from < 6.1 to 6.1.1.
+	if ( '6.1.1' === $wp_version ) {
+		// Unhook default global styles enqueue.
+		remove_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );
+		remove_action( 'wp_footer', 'wp_enqueue_global_styles', 1 );
 
-        // Hook override global styles enqueue.
-        add_action( 'wp_enqueue_scripts', 'wp_hotfix_611_enqueue_global_styles' );
-        add_action( 'wp_footer', 'wp_hotfix_611_enqueue_global_styles', 1 );
+		// Hook override global styles enqueue.
+		add_action( 'wp_enqueue_scripts', 'wp_hotfix_611_enqueue_global_styles' );
+		add_action( 'wp_footer', 'wp_hotfix_611_enqueue_global_styles', 1 );
 
-        // Hook override for block editor styles.
-        add_filter( 'block_editor_settings_all', 'wp_hotfix_611_get_block_editor_settings', PHP_INT_MAX );
+		// Hook override for block editor styles.
+		add_filter( 'block_editor_settings_all', 'wp_hotfix_611_get_block_editor_settings', PHP_INT_MAX );
 
-        // Unhook default cache cleaning mechanism.
-        remove_action( 'switch_theme', array( 'WP_Theme_JSON_Resolver', 'clean_cached_data' ) );
-        remove_action( 'start_previewing_theme', array( 'WP_Theme_JSON_Resolver', 'clean_cached_data' ) );
+		// Unhook default cache cleaning mechanism.
+		remove_action( 'switch_theme', array( 'WP_Theme_JSON_Resolver', 'clean_cached_data' ) );
+		remove_action( 'start_previewing_theme', array( 'WP_Theme_JSON_Resolver', 'clean_cached_data' ) );
 
-        // Hook override cache cleaning mechanism.
-        add_action( 'switch_theme', 'wp_hotfix_611_wp_clean_theme_json_caches' );
-        add_action( 'start_previewing_theme', 'wp_hotfix_611_wp_clean_theme_json_caches' );
-        add_action( 'plugins_loaded', 'wp_hotfix_611_wp_add_non_persistent_theme_json_cache_group' );
-    }
+		// Hook override cache cleaning mechanism.
+		add_action( 'switch_theme', 'wp_hotfix_611_wp_clean_theme_json_caches' );
+		add_action( 'start_previewing_theme', 'wp_hotfix_611_wp_clean_theme_json_caches' );
+		add_action( 'plugins_loaded', 'wp_hotfix_611_wp_add_non_persistent_theme_json_cache_group' );
+	}
 }
 
 /**
@@ -47,43 +47,43 @@ function wp_hotfix_56970_init() {
  * Enqueues the global styles defined via theme.json.
  */
 function wp_hotfix_611_enqueue_global_styles() {
-    $separate_assets  = wp_should_load_separate_core_block_assets();
-    $is_block_theme   = wp_is_block_theme();
-    $is_classic_theme = ! $is_block_theme;
+	$separate_assets  = wp_should_load_separate_core_block_assets();
+	$is_block_theme   = wp_is_block_theme();
+	$is_classic_theme = ! $is_block_theme;
 
-    /*
-     * Global styles should be printed in the head when loading all styles combined.
-     * The footer should only be used to print global styles for classic themes with separate core assets enabled.
-     *
-     * See https://core.trac.wordpress.org/ticket/53494.
-     */
-    if (
-        ( $is_block_theme && doing_action( 'wp_footer' ) ) ||
-        ( $is_classic_theme && doing_action( 'wp_footer' ) && ! $separate_assets ) ||
-        ( $is_classic_theme && doing_action( 'wp_enqueue_scripts' ) && $separate_assets )
-    ) {
-        return;
-    }
+	/*
+	 * Global styles should be printed in the head when loading all styles combined.
+	 * The footer should only be used to print global styles for classic themes with separate core assets enabled.
+	 *
+	 * See https://core.trac.wordpress.org/ticket/53494.
+	 */
+	if (
+		( $is_block_theme && doing_action( 'wp_footer' ) ) ||
+		( $is_classic_theme && doing_action( 'wp_footer' ) && ! $separate_assets ) ||
+		( $is_classic_theme && doing_action( 'wp_enqueue_scripts' ) && $separate_assets )
+	) {
+		return;
+	}
 
-    /*
-     * If loading the CSS for each block separately, then load the theme.json CSS conditionally.
-     * This removes the CSS from the global-styles stylesheet and adds it to the inline CSS for each block.
-     * This filter must be registered before calling wp_get_global_stylesheet();
-     */
-    add_filter( 'wp_theme_json_get_style_nodes', 'wp_filter_out_block_nodes' );
+	/*
+	 * If loading the CSS for each block separately, then load the theme.json CSS conditionally.
+	 * This removes the CSS from the global-styles stylesheet and adds it to the inline CSS for each block.
+	 * This filter must be registered before calling wp_get_global_stylesheet();
+	 */
+	add_filter( 'wp_theme_json_get_style_nodes', 'wp_filter_out_block_nodes' );
 
-    $stylesheet = wp_hotfix_611_get_global_stylesheet();
+	$stylesheet = wp_hotfix_611_get_global_stylesheet();
 
-    if ( empty( $stylesheet ) ) {
-        return;
-    }
+	if ( empty( $stylesheet ) ) {
+		return;
+	}
 
-    wp_register_style( 'global-styles', false, array(), true, true );
-    wp_add_inline_style( 'global-styles', $stylesheet );
-    wp_enqueue_style( 'global-styles' );
+	wp_register_style( 'global-styles', false, array(), true, true );
+	wp_add_inline_style( 'global-styles', $stylesheet );
+	wp_enqueue_style( 'global-styles' );
 
-    // Add each block as an inline css.
-    wp_add_global_styles_for_blocks();
+	// Add each block as an inline css.
+	wp_add_global_styles_for_blocks();
 }
 
 /**
@@ -98,68 +98,68 @@ function wp_hotfix_611_enqueue_global_styles() {
  * @return string Stylesheet.
  */
 function wp_hotfix_611_get_global_stylesheet( $types = array() ) {
-    // Ignore cache when `WP_DEBUG` is enabled, so it doesn't interfere with the theme developers workflow.
-    $can_use_cached = empty( $types ) && ! WP_DEBUG;
-    $cache_key      = 'wp_get_global_stylesheet';
-    $cache_group    = 'theme_json';
-    if ( $can_use_cached ) {
-        $cached = wp_cache_get( $cache_key, $cache_group );
-        if ( $cached ) {
-            return $cached;
-        }
-    }
-    $tree                = WP_Theme_JSON_Resolver::get_merged_data();
-    $supports_theme_json = WP_Theme_JSON_Resolver::theme_has_support();
-    if ( empty( $types ) && ! $supports_theme_json ) {
-        $types = array( 'variables', 'presets', 'base-layout-styles' );
-    } elseif ( empty( $types ) ) {
-        $types = array( 'variables', 'styles', 'presets' );
-    }
+	// Ignore cache when `WP_DEBUG` is enabled, so it doesn't interfere with the theme developers workflow.
+	$can_use_cached = empty( $types ) && ! WP_DEBUG;
+	$cache_key      = 'wp_get_global_stylesheet';
+	$cache_group    = 'theme_json';
+	if ( $can_use_cached ) {
+		$cached = wp_cache_get( $cache_key, $cache_group );
+		if ( $cached ) {
+			return $cached;
+		}
+	}
+	$tree                = WP_Theme_JSON_Resolver::get_merged_data();
+	$supports_theme_json = WP_Theme_JSON_Resolver::theme_has_support();
+	if ( empty( $types ) && ! $supports_theme_json ) {
+		$types = array( 'variables', 'presets', 'base-layout-styles' );
+	} elseif ( empty( $types ) ) {
+		$types = array( 'variables', 'styles', 'presets' );
+	}
 
-    /*
-     * If variables are part of the stylesheet, then add them.
-     * This is so themes without a theme.json still work as before 5.9:
-     * they can override the default presets.
-     * See https://core.trac.wordpress.org/ticket/54782
-     */
-    $styles_variables = '';
-    if ( in_array( 'variables', $types, true ) ) {
-        /*
-         * Only use the default, theme, and custom origins. Why?
-         * Because styles for `blocks` origin are added at a later phase
-         * (i.e. in the render cycle). Here, only the ones in use are rendered.
-         * @see wp_add_global_styles_for_blocks
-         */
-        $origins          = array( 'default', 'theme', 'custom' );
-        $styles_variables = $tree->get_stylesheet( array( 'variables' ), $origins );
-        $types            = array_diff( $types, array( 'variables' ) );
-    }
+	/*
+	 * If variables are part of the stylesheet, then add them.
+	 * This is so themes without a theme.json still work as before 5.9:
+	 * they can override the default presets.
+	 * See https://core.trac.wordpress.org/ticket/54782
+	 */
+	$styles_variables = '';
+	if ( in_array( 'variables', $types, true ) ) {
+		/*
+		 * Only use the default, theme, and custom origins. Why?
+		 * Because styles for `blocks` origin are added at a later phase
+		 * (i.e. in the render cycle). Here, only the ones in use are rendered.
+		 * @see wp_add_global_styles_for_blocks
+		 */
+		$origins          = array( 'default', 'theme', 'custom' );
+		$styles_variables = $tree->get_stylesheet( array( 'variables' ), $origins );
+		$types            = array_diff( $types, array( 'variables' ) );
+	}
 
-    /*
-     * For the remaining types (presets, styles), we do consider origins:
-     *
-     * - themes without theme.json: only the classes for the presets defined by core
-     * - themes with theme.json: the presets and styles classes, both from core and the theme
-     */
-    $styles_rest = '';
-    if ( ! empty( $types ) ) {
-        /*
-         * Only use the default, theme, and custom origins. Why?
-         * Because styles for `blocks` origin are added at a later phase
-         * (i.e. in the render cycle). Here, only the ones in use are rendered.
-         * @see wp_add_global_styles_for_blocks
-         */
-        $origins = array( 'default', 'theme', 'custom' );
-        if ( ! $supports_theme_json ) {
-            $origins = array( 'default' );
-        }
-        $styles_rest = $tree->get_stylesheet( $types, $origins );
-    }
-    $stylesheet = $styles_variables . $styles_rest;
-    if ( $can_use_cached ) {
-        wp_cache_set( $cache_key, $stylesheet, $cache_group );
-    }
-    return $stylesheet;
+	/*
+	 * For the remaining types (presets, styles), we do consider origins:
+	 *
+	 * - themes without theme.json: only the classes for the presets defined by core
+	 * - themes with theme.json: the presets and styles classes, both from core and the theme
+	 */
+	$styles_rest = '';
+	if ( ! empty( $types ) ) {
+		/*
+		 * Only use the default, theme, and custom origins. Why?
+		 * Because styles for `blocks` origin are added at a later phase
+		 * (i.e. in the render cycle). Here, only the ones in use are rendered.
+		 * @see wp_add_global_styles_for_blocks
+		 */
+		$origins = array( 'default', 'theme', 'custom' );
+		if ( ! $supports_theme_json ) {
+			$origins = array( 'default' );
+		}
+		$styles_rest = $tree->get_stylesheet( $types, $origins );
+	}
+	$stylesheet = $styles_variables . $styles_rest;
+	if ( $can_use_cached ) {
+		wp_cache_set( $cache_key, $stylesheet, $cache_group );
+	}
+	return $stylesheet;
 }
 
 /**
@@ -220,8 +220,8 @@ function wp_hotfix_611_get_block_editor_settings( $settings ) {
  * Clean the caches under the theme_json group.
  */
 function wp_hotfix_611_wp_clean_theme_json_caches() {
-    wp_cache_delete( 'wp_get_global_stylesheet', 'theme_json' );
-    WP_Theme_JSON_Resolver::clean_cached_data();
+	wp_cache_delete( 'wp_get_global_stylesheet', 'theme_json' );
+	WP_Theme_JSON_Resolver::clean_cached_data();
 }
 
 /**
@@ -229,5 +229,5 @@ function wp_hotfix_611_wp_clean_theme_json_caches() {
  * stored under the wp_get_global_stylesheet cache group.
  */
 function wp_hotfix_611_wp_add_non_persistent_theme_json_cache_group() {
-    wp_cache_add_non_persistent_groups( 'theme_json' );
+	wp_cache_add_non_persistent_groups( 'theme_json' );
 }

--- a/hotfix-56970.php
+++ b/hotfix-56970.php
@@ -169,7 +169,51 @@ function wp_hotfix_611_get_global_stylesheet( $types = array() ) {
  * @return array New block editor settings.
  */
 function wp_hotfix_611_get_block_editor_settings( $settings ) {
-    return $settings;
+	// Recreate global styles.
+	$new_global_styles = array();
+	$presets           = array(
+		array(
+			'css'            => 'variables',
+			'__unstableType' => 'presets',
+			'isGlobalStyles' => true,
+		),
+		array(
+			'css'            => 'presets',
+			'__unstableType' => 'presets',
+			'isGlobalStyles' => true,
+		),
+	);
+	foreach ( $presets as $preset_style ) {
+		$actual_css = wp_hotfix_611_get_global_stylesheet( array( $preset_style['css'] ) );
+		if ( '' !== $actual_css ) {
+			$preset_style['css'] = $actual_css;
+			$new_global_styles[] = $preset_style;
+		}
+	}
+
+	if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
+		$block_classes = array(
+			'css'            => 'styles',
+			'__unstableType' => 'theme',
+			'isGlobalStyles' => true,
+		);
+	} else {
+		// If there is no `theme.json` file, ensure base layout styles are still available.
+		$block_classes = array(
+			'css'            => 'base-layout-styles',
+			'__unstableType' => 'base-layout',
+			'isGlobalStyles' => true,
+		);
+	}
+	$styles_css = wp_hotfix_611_get_global_stylesheet( array( $block_classes['css'] ) );
+	if ( '' !== $styles_css ) {
+		$block_classes['css'] = $styles_css;
+		$new_global_styles[]  = $block_classes;
+	}
+
+	$settings['styles'] = array_merge( $new_global_styles, get_block_editor_theme_styles() );
+
+	return $settings;
 }
 
 /**


### PR DESCRIPTION
Creates a testing plugin with the proposed updates from [PR 3712](https://github.com/WordPress/wordpress-develop/pull/3712).

See [Trac 56970](https://core.trac.wordpress.org/ticket/56970) ([fix commentary starts here](https://core.trac.wordpress.org/ticket/56970#comment:50)).

(Please excuse the whole `trunk` => `main` thing, it IS intentional. Juggling branch names to get the PR to work 😉 )